### PR TITLE
Optimize image loading

### DIFF
--- a/document/img.go
+++ b/document/img.go
@@ -92,6 +92,19 @@ func NewIMG(logger *slog.Logger, src string, cfg *Config) (*img, error) {
 	}, nil
 }
 
+// LoadEXIF populates im's EXIF information without decoding the entire image.
+func (im *img) LoadEXIF() error {
+	f, err := os.Open(im.SourcePath)
+	if err != nil {
+		return fmt.Errorf("can't read %q: %w", im.SourcePath, err)
+	}
+	defer f.Close()
+	if err := im.loadEXIF(f); err != nil {
+		return fmt.Errorf("cannot get camera for %q: %w", im.SourcePath, err)
+	}
+	return nil
+}
+
 func (im *img) Load(r io.Reader) error {
 	if err := im.loadEXIF(r); err != nil {
 		return fmt.Errorf(

--- a/document/winter.go
+++ b/document/winter.go
@@ -326,6 +326,16 @@ func (s *Substructure) ExecuteAll(dist string) error {
 					im.WebPath,
 				)
 			}
+			fresh, err := im.generatedPhotosAreFresh(im.SourcePath)
+			if err != nil {
+				return fmt.Errorf("cannot check freshness of %q: %w", im.SourcePath, err)
+			}
+			if fresh {
+				if err := im.LoadEXIF(); err != nil {
+					return fmt.Errorf("cannot load exif for %q: %w", im.SourcePath, err)
+				}
+				continue
+			}
 			srcf, err := os.Open(im.SourcePath)
 			if err != nil {
 				return fmt.Errorf("cannot open image: %w", err)
@@ -334,13 +344,6 @@ func (s *Substructure) ExecuteAll(dist string) error {
 			dest := filepath.Join(dist, im.WebPath)
 			if err := im.Load(srcf); err != nil {
 				return fmt.Errorf("cannot load image: %w", err)
-			}
-			fresh, err := im.generatedPhotosAreFresh(im.SourcePath)
-			if err != nil {
-				return fmt.Errorf("cannot check freshness of %q: %w", im.SourcePath, err)
-			}
-			if fresh {
-				continue
 			}
 			if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 				return fmt.Errorf("cannot make gallery dir %q: %w", filepath.Dir(dest), err)


### PR DESCRIPTION
## Summary
- add lightweight LoadEXIF to parse photo metadata only
- check image cache before loading image data

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_683faf2d5e7c8332aecc31039c658509