### PR TITLE
Add build summary output

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -64,6 +64,14 @@ func newBuildCmd(logger *slog.Logger) *cobra.Command {
 				return err
 			}
 
+			if !*serve {
+				cliutils.Printf(
+					"Build complete! Generated %d pages and %d images. Stay frosty!\n",
+					s.DocumentCount(),
+					s.ImageCount(),
+				)
+			}
+
 			if *serve {
 				baseURL := url.URL{
 					Scheme: "http",

--- a/document/winter.go
+++ b/document/winter.go
@@ -228,6 +228,23 @@ func NewSubstructure(logger *slog.Logger, cfg *Config) (*Substructure, error) {
 	return &s, s.discover()
 }
 
+// DocumentCount returns the number of documents known to the substructure.
+func (s *Substructure) DocumentCount() int {
+	if s.docs == nil {
+		return 0
+	}
+	return len(s.docs.All)
+}
+
+// ImageCount returns the total number of images across all galleries.
+func (s *Substructure) ImageCount() int {
+	total := 0
+	for _, imgs := range s.galleries {
+		total += len(imgs)
+	}
+	return total
+}
+
 // Build builds doc.
 //
 // To also build downstream dependencies, use [Rebuild] instead.


### PR DESCRIPTION
## Summary
- show a friendly summary after a build finishes
- track document and image counts in the substructure

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68412f48e6388332bd7d174c4edec36f