### PR TITLE
Fix Reloader websocket shutdown

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -81,6 +81,7 @@ func newBuildCmd(logger *slog.Logger) *cobra.Command {
 				reloader := Reloader{
 					Ignore:       ignoreDirectories,
 					Substructure: s,
+					closeSockets: make(chan struct{}),
 				}
 
 				var mux http.ServeMux


### PR DESCRIPTION
## Summary
- ensure Reloader has a valid `closeSockets` channel in build command

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684a512730dc833288ea9c468ae762f7